### PR TITLE
refactor: switched id controller value in did

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,9 +87,9 @@ async function createDIDFile() {
     'id': process.env.VERIFICATION_METHOD,
     'verificationMethod': [
       {
-        'id': 'did:web:compliance.gaia-x.eu#JWK2020-RSA',
-        "type": "JsonWebKey2020", 
-        "controller" : process.env.verificationMethod,
+        'id' : process.env.verificationMethod,
+        'type': "JsonWebKey2020", 
+        'controller': 'did:web:compliance.gaia-x.eu#JWK2020-RSA', 
         '@context': 'https://w3c-ccg.github.io/lds-jws2020/contexts/v1/',
         publicKeyJwk
       }


### PR DESCRIPTION
## Proposed Changes
Switch the value of id and controller in did verfication method to conform to the specification.


A controller is an entity that is authorized to make changes to a DID Document (https://www.w3.org/TR/did-core/#did-controller)

A DID is expressed using ID and which allows theoretically DID that are not part of the subject DID (https://www.w3.org/TR/did-core/#did-subject) but since for Assertion Methods (https://www.w3.org/TR/did-core/#assertion) when used in the short form of "did:example..." the allowed did must match an ID of an Verification Method (or explicit define a new Verification Method under Assertion) even on the earlier stages it makes more sence to have the ID from the DID Subject and the Controller to be the complicance service.

See also the note on the did core spec: 

> "NOTE: Verification method controller(s) and DID controller(s)
The semantics of the controller property are the same when the subject of the relationship is the [DID document](https://www.w3.org/TR/did-core/#dfn-did-documents) as when the subject of the relationship is a [verification method](https://www.w3.org/TR/did-core/#dfn-verification-method), such as a cryptographic public key. Since a key can't control itself, and the key controller cannot be inferred from the [DID document](https://www.w3.org/TR/did-core/#dfn-did-documents), it is necessary to explicitly express the identity of the controller of the key. The difference is that the value of controller for a [verification method](https://www.w3.org/TR/did-core/#dfn-verification-method) is not necessarily a [DID controller](https://www.w3.org/TR/did-core/#dfn-did-controllers). [DID controllers](https://www.w3.org/TR/did-core/#dfn-did-controllers) are expressed using the [controller](https://www.w3.org/TR/did-core/#dfn-controller) property at the highest level of the [DID document](https://www.w3.org/TR/did-core/#dfn-did-documents) (the topmost [map](https://infra.spec.whatwg.org/#ordered-map) in the [data model](https://www.w3.org/TR/did-core/#data-model)); see [§ 5.1.2 DID Controller](https://www.w3.org/TR/did-core/#did-controller)."
