### PR TITLE
Fix incorrect DID Document generation and examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@
             "LegalPerson"
         ],
         "id": "https://compliance.gaia-x.eu/.well-known/participant.json",
-        "issuer": "did:web:compliance.gaia-x.eu",
+        "issuer": "did:web:example.com",
         "issuanceDate": "2022-09-23T23:23:23.235Z",
         "credentialSubject": {
-            "id": "did:web:compliance.gaia-x.eu",
+            "id": "did:web:example.com",
             "gx-participant:name": "Gaia-X AISBL",
             "gx-participant:legalName": "Gaia-X European Association for Data and Cloud AISBL",
             "gx-participant:registrationNumber": {
@@ -79,7 +79,7 @@
             "type": "JsonWebSignature2020",
             "created": "2022-10-01T13:02:09.771Z",
             "proofPurpose": "assertionMethod",
-            "verificationMethod": "did:web:compliance.gaia-x.eu",
+            "verificationMethod": "did:web:example.com#JWK2020-RSA",
             "jws": "eyJhbGciOiJSUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..XQqRvvuxW1xHUy_eRzOk4LwyjwlRofg0JBiO0nrWGHAjwMA87OVJ37mB6GylgEttEaUjXQV-QmbGfEnE-YQf5S7B-id9Lld-CC-vW8M-2EvXh3oQp3l5W35mvvdVQXBj16LLskQZpfZGRHM0hn7zGEw24fDc_tLaGoNR9LQ6UzmSrHMwFFVWz6XH3RoG-UY0aZDpnAxjpWxUWaa_Jzf65bfNlx2EdSv3kIKKYJLUlQTk0meuFDD23VrkGStQTGQ8GijY3BNo6QWw889tt5YKWtiSZjbDYYHsVCwMzPoKT0hVJ1wy2ve6pJ4MSYfhiMxoDq6YBOm-oYKYfBeN22fjqQ"
         }
    }
@@ -166,7 +166,7 @@
        "issuer": "did:web:compliance.gaia-x.eu",
        "issuanceDate": "2022-10-01T13:02:17.489Z",
        "credentialSubject": {
-         "id": "did:example.com",
+         "id": "did:web:example.com",
          "hash": "3280866b1b8509ce287850fb113dc76d1334959c759f82a57415164d7a3a4026"
        },
        "proof": {
@@ -174,7 +174,7 @@
          "created": "2022-10-01T13:02:17.489Z",
          "proofPurpose": "assertionMethod",
          "jws": "eyJhbGciOiJQUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YQAIjkqX6OL4U3efV0zumn8-l8c4wQo98SOSlzt53HOR8qlLu5L5lmwZJnAsR7gKW-6jv5GBT0X4ORQ1ozLvihFj6eaxxJNgzLFPoH5w9UEaEIO8mMGyeQ-YQYWBbET3IK1mcHm2VskEsvpLvQGnk6kYJCXJzmaHMRSF3WOjNq_JWN8g-SldiGhgfKsJvIkjCeRm3kCt_UVeHMX6SoLMFDjI8JVxD9d5AG-kbK-xb13mTMdtbcyBtBJ_ahQcbNaxH-CfSDTSN51szLJBG-Ok-OlMagHY_1dqViXAKl4T5ShoS9fjxQItJvFPGA14axkY6s00xKVCUusi31se6rxC9g",
-         "verificationMethod": "did:web:compliance.gaia-x.eu"
+         "verificationMethod": "did:web:compliance.gaia-x.eu#X509-JWK2020"
        }
      }
    }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## How To Use
 
 1. Update the self description in `self-description.json`, replace it with your own. See details in the [Architecture Document](https://gaia-x.gitlab.io/policy-rules-committee/trust-framework/participant/)
-2. Create a new `.env` file in the `/config` directory with `PRIVATE_KEY`, `CERTIFICATE`, `CONTROLLER`, `VERIFICATION_METHOD` and `X5U_URL` as properties. Feel free to use the example file `example.env` located in the `/config` directory. You could quickly copy the file with the following command:
+2. Create a new `.env` file in the `/config` directory with `PRIVATE_KEY`, `CERTIFICATE`, `DID`, `X5U_URL` and optionally `CONTROLLER`, `VERIFICATION_METHOD` as properties. Feel free to use the example file `example.env` located in the `/config` directory. You could quickly copy the file with the following command:
 
    ```sh
    cp config/example.env config/.env
@@ -85,20 +85,20 @@
    }
    ```
 
-5. In addition, a `did.json` will be created based on the provided `CERTIFICATE` and `VERIFICATION_METHOD`
+5. In addition, a `did.json` will be created based on the provided `CERTIFICATE`, `DID` and optional `CONTROLLER` and `VERIFICATION_METHOD`
 
    **Example `did.json`:**
 
    ```json
    {
      "@context": ["https://www.w3.org/ns/did/v1"],
-     "id": "did:web:compliance.gaia-x.eu",
+     "id": "did:web:example.com",
      "verificationMethod": [
        {
          "@context": "https://w3c-ccg.github.io/lds-jws2020/contexts/v1/",
-         "id": "did:web:compliance.gaia-x.eu",
+         "id": "did:web:example.com#JWK2020-RSA",
          "type": "JsonWebKey2020",
-         "controller": "did:web:compliance.gaia-x.eu#JWK2020-RSA",
+         "controller": "did:web:example.com",
          "publicKeyJwk": {
            "kty": "RSA",
            "n": "ulmXEa0nehbR338h6QaWLjMqfXE7mKA9PXoC_6_8d26xKQuBKAXa5k0uHhzQfNlAlxO-IpCDgf9cVzxIP-tkkefsjrXc8uvkdKNK6TY9kUxgUnOviiOLpHe88FB5dMTH6KUUGkjiPfq3P0F9fXHDEoQkGSpWui7eD897qSEdXFre_086ns3I8hSVCxoxlW9guXa_sRISIawCKT4UA3ZUKYyjtu0xRy7mRxNFh2wH0iSTQfqf4DWUUThX3S-jeRCRxqOGQdQlZoHym2pynJ1IYiiIOMO9L2IQrQl35kx94LGHiF8r8CRpLrgYXTVd9U17-nglrUmJmryECxW-555ppQ",
@@ -108,7 +108,7 @@
          }
        }
      ],
-     "assertionMethod": ["did:web:compliance.gaia-x.eu#JWK2020-RSA"]
+     "assertionMethod": ["did:web:example.com#JWK2020-RSA"]
    }
    ```
 
@@ -127,10 +127,10 @@
        ],
        "type": ["VerifiableCredential", "LegalPerson"],
        "id": "https://compliance.gaia-x.eu/.well-known/participant.json",
-       "issuer": "did:web:compliance.gaia-x.eu",
+       "issuer": "did:web:example.com",
        "issuanceDate": "2022-09-23T23:23:23.235Z",
        "credentialSubject": {
-         "id": "did:web:compliance.gaia-x.eu",
+         "id": "did:web:example.com",
          "gx-participant:name": "Gaia-X AISBL",
          "gx-participant:legalName": "Gaia-X European Association for Data and Cloud AISBL",
          "gx-participant:registrationNumber": {
@@ -155,7 +155,7 @@
          "type": "JsonWebSignature2020",
          "created": "2022-10-01T13:02:09.771Z",
          "proofPurpose": "assertionMethod",
-         "verificationMethod": "did:web:compliance.gaia-x.eu",
+         "verificationMethod": "did:web:example.com#JWK2020-RSA",
          "jws": "eyJhbGciOiJSUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..XQqRvvuxW1xHUy_eRzOk4LwyjwlRofg0JBiO0nrWGHAjwMA87OVJ37mB6GylgEttEaUjXQV-QmbGfEnE-YQf5S7B-id9Lld-CC-vW8M-2EvXh3oQp3l5W35mvvdVQXBj16LLskQZpfZGRHM0hn7zGEw24fDc_tLaGoNR9LQ6UzmSrHMwFFVWz6XH3RoG-UY0aZDpnAxjpWxUWaa_Jzf65bfNlx2EdSv3kIKKYJLUlQTk0meuFDD23VrkGStQTGQ8GijY3BNo6QWw889tt5YKWtiSZjbDYYHsVCwMzPoKT0hVJ1wy2ve6pJ4MSYfhiMxoDq6YBOm-oYKYfBeN22fjqQ"
        }
      },
@@ -166,7 +166,7 @@
        "issuer": "did:web:compliance.gaia-x.eu",
        "issuanceDate": "2022-10-01T13:02:17.489Z",
        "credentialSubject": {
-         "id": "did:web:compliance.gaia-x.eu",
+         "id": "did:example.com",
          "hash": "3280866b1b8509ce287850fb113dc76d1334959c759f82a57415164d7a3a4026"
        },
        "proof": {
@@ -195,7 +195,9 @@ How to set signer tool environment variables:
 
 - `PRIVATE_KEY` = copy `pk8key.pem` content
 - `CERTIFICATE ` = copy `cert.pem` content
-- `VERIFICATION_METHOD` = `did:web:localhost%3A3000` (assuming port `3000` for the compliance service, you have to encode `:` as `%3A`)
+- `DID` = `did:web:localhost%3A3000` (assuming port `3000` for the compliance service, you have to encode `:` as `%3A`)
+- `CONTROLLER` = `did:web:localhost%3A3000` (assuming port `3000` for the compliance service, you have to encode `:` as `%3A`)
+- `VERIFICATION_METHOD` = `did:web:localhost%3A3000#X509` The Verification Method (Public Key) identifier. Needs to include the value from `DID` suffixed with `#` and then the actual Verification Method ID
 - `X5U_URL` = `https://localhost:3000/.well-known/x509CertificateChain.pem`
 - `BASE_URL` = `https://localhost:3000`
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ How to set signer tool environment variables:
 - `CERTIFICATE ` = copy `cert.pem` content
 - `DID` = `did:web:localhost%3A3000` (assuming port `3000` for the compliance service, you have to encode `:` as `%3A`)
 - `CONTROLLER` = `did:web:localhost%3A3000` (assuming port `3000` for the compliance service, you have to encode `:` as `%3A`)
-- `VERIFICATION_METHOD` = `did:web:localhost%3A3000#X509` The Verification Method (Public Key) identifier. Needs to include the value from `DID` suffixed with `#` and then the actual Verification Method ID
+- `VERIFICATION_METHOD` = `did:web:localhost%3A3000#JWK2020-RSA` The Verification Method (Public Key) identifier. Needs to include the value from `DID` suffixed with `#` and then the actual Verification Method ID
 - `X5U_URL` = `https://localhost:3000/.well-known/x509CertificateChain.pem`
 - `BASE_URL` = `https://localhost:3000`
 

--- a/config/example.env
+++ b/config/example.env
@@ -12,5 +12,5 @@ X5U_URL="https://delta-dao.com/.well-known/x509CertificateChain.pem"
 API_VERSION="2206"
 BASE_URL="https://compliance.gaia-x.eu"
 DID="did:web:delta-dao.com"
-CONTROLLER=`${DID}`
-VERIFICATION_METHOD=`${DID}#X509`
+CONTROLLER="did:web:delta-dao.com"
+VERIFICATION_METHOD="did:web:delta-dao.com#JWK2020-RSA"

--- a/config/example.env
+++ b/config/example.env
@@ -8,8 +8,9 @@ MIIFNjCCBBARFMEMw+ilFBpIFa36tz9B9...
 ...
 ...FpaBQV63X62OZYA6
 -----END CERTIFICATE-----"
-VERIFICATION_METHOD="did:web:delta-dao.com#X509"
 X5U_URL="https://delta-dao.com/.well-known/x509CertificateChain.pem"
 API_VERSION="2206"
 BASE_URL="https://compliance.gaia-x.eu"
-CONTROLLER="did:web:delta-dao.com"
+DID="did:web:delta-dao.com"
+CONTROLLER=`${DID}`
+VERIFICATION_METHOD=`${DID}#X509`

--- a/index.js
+++ b/index.js
@@ -12,8 +12,10 @@ const CURRENT_TIME = new Date().getTime()
 const BASE_URL = process.env.BASE_URL || 'https://compliance.gaia-x.eu'
 const API_VERSION = process.env.API_VERSION
 
+const VM_ID = process.env.VERIFICATION_METHOD ?? `${process.env.DID}#JWK2020-RSA`
+
 const OUTPUT_DIR = process.argv.slice(2)[1] || './output/'
-createOutputFolder(OUTPUT_DIR)
+await createOutputFolder(OUTPUT_DIR)
 
 const TYPE_API_ATH = {
   ServiceOfferingExperimental: 'service-offering',
@@ -58,8 +60,7 @@ async function createProof(hash) {
     type: 'JsonWebSignature2020',
     created: new Date(CURRENT_TIME).toISOString(),
     proofPurpose: 'assertionMethod',
-    verificationMethod:
-      process.env.VERIFICATION_METHOD ?? 'did:web:compliance.lab.gaia-x.eu',
+    verificationMethod: VM_ID ?? 'did:web:compliance.lab.gaia-x.eu',
     jws: await sign(hash),
   }
 
@@ -108,19 +109,20 @@ async function createDIDFile() {
   publicKeyJwk.alg = algorithm
   publicKeyJwk.x5u = process.env.X5U_URL
 
+
   const did = {
     '@context': ['https://www.w3.org/ns/did/v1'],
-    id: process.env.VERIFICATION_METHOD,
+    id: process.env.DID,
     verificationMethod: [
       {
         '@context': 'https://w3c-ccg.github.io/lds-jws2020/contexts/v1/',
-        id: process.env.VERIFICATION_METHOD,
+        id: VM_ID,
         type: 'JsonWebKey2020',
-        controller: process.env.CONTROLLER,
+        controller: process.env.CONTROLLER ?? process.env.DID,
         publicKeyJwk,
       },
     ],
-    assertionMethod: [process.env.VERIFICATION_METHOD + '#JWK2020-RSA'],
+    assertionMethod: [VM_ID],
   }
 
   const data = JSON.stringify(did, null, 2)
@@ -224,4 +226,4 @@ async function main() {
   }
 }
 
-main()
+await main()

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/deltaDAO/self-description-signer#readme",
   "dependencies": {
-    "axios": "^0.27.2",
-    "dotenv": "^16.0.1",
-    "jose": "^4.8.1"
+    "axios": "^1.2.1",
+    "dotenv": "^16.0.3",
+    "jose": "^4.11.1"
   }
 }


### PR DESCRIPTION
The signer creates the DID Documents incorrectly. The Verification Relationship (asertionMethod), points to a VM that does not exist in the DID Document.

- Added new variables for a DID, which could be used as the only param for DID creation.
- Also fixed the examples and updated the self description DID to another value, as it could be highly confusing to new people to us the compliance service DID:web for the examples.

Warning:
Do not merge yet as the changes have not been tested yet.
